### PR TITLE
Upgrade react-native-tcp

### DIFF
--- a/shims-browserify.js
+++ b/shims-browserify.js
@@ -27,6 +27,6 @@ module.exports = {
   "url": "~0.10.1",
   "util": "~0.10.1",
   "utp": "0.0.8",
-  "react-native-tcp": "^1.0.1",
+  "react-native-tcp": "^2.0.4",
   "vm-browserify": "~0.0.1"
 }

--- a/shims.js
+++ b/shims.js
@@ -27,6 +27,6 @@ module.exports = {
   "tty-browserify": "0.0.0",
   "url": "~0.10.1",
   "util": "~0.10.3",
-  "react-native-tcp": "^1.0.1",
+  "react-native-tcp": "^2.0.4",
   "vm-browserify": "0.0.4"
 }


### PR DESCRIPTION
I found a bug in the iOS10.
After running `react-native run-ios` , an error has occurred.

```
PhaseScriptExecution Run\ Script /Users/XXXXX/Library/Developer/Xcode/DerivedData/XXXXXX-czzbbirolpxzpafalsjxgwqfqgln/Build/Intermediates/TcpSockets.build/Debug-iphoneos/TcpSockets.build/Script-73D9379C1AFFA3E100450142.sh
    cd /Users/XXXXX/workspace/XXXXXX/node_modules/react-native-tcp/ios
    ~
    export SDK_NAME=iphoneos10.0
    ~
    export SDK_VERSION=10.0
    ~
    /bin/sh -c /Users/XXXXX/Library/Developer/Xcode/DerivedData/XXXXXX-czzbbirolpxzpafalsjxgwqfqgln/Build/Intermediates/TcpSockets.build/Debug-iphoneos/TcpSockets.build/Script-73D9379C1AFFA3E100450142.sh

XCode has selected SDK: iphoneos with version: 0.0 (although back-targetting: 7.0)
...therefore, OTHER_SDK_TO_BUILD = iphonesimulator0.0
RECURSION: I am the root ... recursing all missing build targets NOW...
RECURSION: ...about to invoke: xcodebuild -configuration "Debug" -project "TcpSockets.xcodeproj" -target "TcpSockets" -sdk "iphonesimulator0.0" build RUN_CLANG_STATIC_ANALYZER=NO BUILD_DIR="/Users/XXXXX/Library/Developer/Xcode/DerivedData/XXXXXX-czzbbirolpxzpafalsjxgwqfqgln/Build/Products" BUILD_ROOT="/Users/XXXXX/Library/Developer/Xcode/DerivedData/XXXXXX-czzbbirolpxzpafalsjxgwqfqgln/Build/Products" SYMROOT="/Users/XXXXX/Library/Developer/Xcode/DerivedData/XXXXXX-czzbbirolpxzpafalsjxgwqfqgln/Build/Products"
2016-09-24 19:09:23.158 xcodebuild[3620:133385] [MT] PluginLoading: Required plug-in compatibility UUID 8A66E736-A720-4B3C-92F1-33D9962C69DF for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin' not present in DVTPlugInCompatibilityUUIDs
xcodebuild: error: SDK "iphonesimulator0.0" cannot be located.
Command /bin/sh failed with exit code 64
```
Since the version of react-native-tcp 1.0.1 is the cause, I have upgraded it.
