### PR TITLE
Check file path in cross platform friendly way

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -178,7 +178,7 @@ function hackPackageJSONs (modules, done) {
   var finder = find('./node_modules')
 
   finder.on('file', function (file) {
-    if (!/\/package\.json$/.test(file)) return
+    if (path.basename(file) !== 'package.json') return
 
     fixPackageJSON(modules, file, true)
   })
@@ -187,7 +187,7 @@ function hackPackageJSONs (modules, done) {
 }
 
 function fixPackageJSON (modules, file, overwrite) {
-  if (/\/react\-native\//.test(file)) return
+  if (file.split(path.sep).indexOf('react-native') >= 0) return
 
   fs.readFile(path.resolve(file), { encoding: 'utf8' }, function (err, contents) {
     if (err) throw err


### PR DESCRIPTION
package.json files of dependencies don't get patched on Windows.

This change checks the file names in a way that works on both Windows and *nix.