### PR TITLE
swap os-browserify for react-native-os

### DIFF
--- a/browser.json
+++ b/browser.json
@@ -8,7 +8,7 @@
   "domain": "domain-browser",
   "http": "react-native-http",
   "https": "https-browserify",
-  "os": "os-browserify",
+  "os": "react-native-os",
   "path": "path-browserify",
   "querystring": "querystring-es3",
   "fs": "react-native-level-fs",

--- a/shims.js
+++ b/shims.js
@@ -12,7 +12,7 @@ module.exports = {
   "events": "^1.0.0",
   "react-native-http": "tradle/react-native-http#834492d",
   "https-browserify": "~0.0.0",
-  "os-browserify": "~0.1.2",
+  "react-native-os": "^1.0.1",
   "path-browserify": "0.0.0",
   "process": "^0.11.0",
   "punycode": "^1.2.4",


### PR DESCRIPTION
react-native-os replaces os-browserify's networkInterfaces/getNewtorkInterfaces stub with implementation