### PR TITLE
:pencil: Make the `./shims.js` links clicable.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,14 +4,14 @@ Run after npm install and you can use node core modules and npm modules that use
 
 ## What is solves
 
-If your project has no non-React-Native dependencies, you don't need this module, and you should just check out ['./shims.js']('./shims.js') for the core node modules to use individually.
+If your project has no non-React-Native dependencies, you don't need this module, and you should just check out ['./shims.js'](./shims.js) for the core node modules to use individually.
 
 However, with bigger projects that don't reimplement every wheel from scratch, somewhere in your dependency tree, something uses a core node module. I found myself building this because in my React Native app, I wanted to use [bitcoinjs-lib](https://github.com/bitcoinjs/bitcoinjs-lib), [levelup](https://github.com/Level/levelup), [bittorrent-dht](https://github.com/feross/bittorrent-dht), and lots of fun crypto. If that sounds like you, keep reading. 
 
 ## What it does
 
 `rn-nodeify --install`  
-installs shims for core node modules, see ['./shims.js']('./shims.js') for the current mappings. It recurses down `node_modules` and modifies all the `package.json`'s in there to add/update the `browser` and `react-native` fields. It sounds scary because it is. However, it does work.
+installs shims for core node modules, see ['./shims.js'](./shims.js) for the current mappings. It recurses down `node_modules` and modifies all the `package.json`'s in there to add/update the `browser` and `react-native` fields. It sounds scary because it is. However, it does work.
 
 `rn-nodeify --hack`  
 Now that you're scared, I should also mention that there are some package-specific hacks (see [./pkg-hacks.js]('./pkg-hacks.js')), for when the React Native packager choked on something that Webpack and Browserify swallowed.


### PR DESCRIPTION
It was pointing to an incorrect url (with actual `'` on it).