### PR TITLE
Update react-native-tcp to Support react-native >= 0.40.0

### DIFF
--- a/shims-browserify.js
+++ b/shims-browserify.js
@@ -27,6 +27,6 @@ module.exports = {
   "url": "~0.10.1",
   "util": "~0.10.1",
   "utp": "0.0.8",
-  "react-native-tcp": "^2.0.4",
+  "react-native-tcp": "^3.2.1",
   "vm-browserify": "~0.0.1"
 }

--- a/shims.js
+++ b/shims.js
@@ -27,6 +27,6 @@ module.exports = {
   "tty-browserify": "0.0.0",
   "url": "~0.10.1",
   "util": "~0.10.3",
-  "react-native-tcp": "^2.0.4",
+  "react-native-tcp": "^3.2.1",
   "vm-browserify": "0.0.4"
 }


### PR DESCRIPTION
rn-nodeify was overriding my version of react-native-tcp with an older version (2.0.4) when running `rn-nodeify --install stream,process,util,net --hack`, which was problematic because react-native >= 0.40.0 is incompatible with 2.0.4 because of this deprecation: http://tekkie.ro/quick-n-dirty/support-react-native-0.40-ios-headers/

I have tested my branch by npm installing it into my project.