### PR TITLE
Basic yarn support

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -26,7 +26,9 @@ var argv = minimist(process.argv.slice(2), {
   }
 })
 
-var BASE_INSTALL_LINE = argv.yarn ? 'yarn add' : 'npm install --save'
+var BASE_INSTALL_LINE = argv.yarn ?
+  '_rn_nodeify_flag=1 yarn add' :
+  'npm install --save'
 
 if (argv.help) {
   runHelp()
@@ -36,6 +38,12 @@ if (argv.help) {
 }
 
 function run () {
+  if (argv.yarn && process.env._rn_nodeify_flag) {
+    // Do not recursively run rn-nodeify, this can be an
+    // issue with yarn when --overwrite is set
+    return
+  }
+
   var toShim
   if (argv.install) {
     if (argv.install === true) {
@@ -314,6 +322,8 @@ function runHelp () {
         -h  --help                  show usage
         -e, --hack                  run package-specific hacks (list or leave blank to run all)
         -i, --install               install shims (list or leave blank to install all)
+        -o, --overwrite             updates installed packages if a newer version is available
+        -y, --yarn                  use yarn to install packages instead of npm (experimental)
 
     Please report bugs!  https://github.com/mvayngrib/rn-nodeify/issues
     */

--- a/cmd.js
+++ b/cmd.js
@@ -27,9 +27,7 @@ var argv = minimist(process.argv.slice(2), {
   }
 })
 
-var BASE_INSTALL_LINE = argv.yarn ?
-  '_rn_nodeify_flag=1 yarn add' :
-  'npm install --save'
+var BASE_INSTALL_LINE = argv.yarn ? 'yarn add' : 'npm install --save'
 
 if (argv.help) {
   runHelp()
@@ -39,12 +37,6 @@ if (argv.help) {
 }
 
 function run () {
-  if (argv.yarn && process.env._rn_nodeify_flag) {
-    // Do not recursively run rn-nodeify, this can be an
-    // issue with yarn when --overwrite is set
-    return
-  }
-
   var toShim
   if (argv.install) {
     if (argv.install === true) {

--- a/cmd.js
+++ b/cmd.js
@@ -21,11 +21,12 @@ var argv = minimist(process.argv.slice(2), {
     h: 'help',
     i: 'install',
     e: 'hack',
-    o: 'overwrite'
+    o: 'overwrite',
+    y: 'yarn'
   }
 })
 
-var BASE_INSTALL_LINE = 'npm install --save'
+var BASE_INSTALL_LINE = argv.yarn ? 'yarn add' : 'npm install --save'
 
 if (argv.help) {
   runHelp()
@@ -155,7 +156,11 @@ function installShims ({ modules, overwrite }, done) {
       let version = allShims[name]
       if (!version) return
       if (version.indexOf('/') === -1) {
-        log('installing from npm', name)
+        if (argv.yarn) {
+          log('installing from yarn', name)
+        } else {
+          log('installing from npm', name)
+        }
         installLine += name + '@' + version
       } else {
         // github url

--- a/cmd.js
+++ b/cmd.js
@@ -152,7 +152,7 @@ function installShims ({ modules, overwrite }, done) {
               if (semver.satisfies(existingVer, allShims[name])) {
                 install = false
               }
-            } else {
+            } else if (existingVer) {
               // To be considered up-to-date, we need an exact match,
               // after doing some normalization of github url's
               if (existingVer.startsWith('github:')) {

--- a/cmd.js
+++ b/cmd.js
@@ -149,25 +149,26 @@ function installShims ({ modules, overwrite }, done) {
               install = false
             }
           } else {
-            var existingVer = (lockfile[name] || {}).version
+            var lockfileVer = (lockfile[name] || {}).version
             var targetVer = allShims[name]
-            if (semver.valid(existingVer)) {
-              if (semver.satisfies(existingVer, targetVer)) {
+            if (semver.valid(lockfileVer)) {
+              if (semver.satisfies(lockfileVer, targetVer)) {
                 install = false
               }
-            } else if (existingVer) {
+            } else if (lockfileVer) {
               // To be considered up-to-date, we need an exact match,
               // after doing some normalization of github url's
-              if (existingVer.startsWith('github:')) {
-                existingVer = existingVer.slice(7)
+              if (lockfileVer.startsWith('github:')) {
+                lockfileVer = lockfileVer.slice(7)
               }
-              if (existingVer.indexOf(targetVer) == 0) {
+              if (lockfileVer.indexOf(targetVer) == 0) {
                 install = false
               }
             }
           }
         } else {
           // Fallback to using the version from the dependency's package.json
+          var pkgJson = require(modPath + '/package.json')
           if (/^git\:\/\//.test(pkgJson._resolved)) {
             var hash = allShims[name].split('#')[1]
             if (hash && pkgJson.gitHead.indexOf(hash) === 0) {

--- a/cmd.js
+++ b/cmd.js
@@ -128,7 +128,10 @@ function installShims ({ modules, overwrite }, done) {
   } else {
     var lockpath = path.join(process.cwd(), 'package-lock.json')
     if (fs.existsSync(lockpath)) {
-      lockfile = require(lockpath)
+      let result = require(lockpath)
+      if (result && result.dependencies) {
+        lockfile = result.dependencies
+      }
     }
   }
 
@@ -149,7 +152,7 @@ function installShims ({ modules, overwrite }, done) {
             var existingVer = (lockfile[name] || {}).version
             var targetVer = allShims[name]
             if (semver.valid(existingVer)) {
-              if (semver.satisfies(existingVer, allShims[name])) {
+              if (semver.satisfies(existingVer, targetVer)) {
                 install = false
               }
             } else if (existingVer) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "bin": "./cmd.js",
   "license": "MIT",
   "dependencies": {
+    "@yarnpkg/lockfile": "^1.0.0",
     "deep-equal": "^1.0.0",
     "findit": "^2.0.0",
     "fs-extra": "^0.22.1",


### PR DESCRIPTION
I was running into #42 and downgrading NPM didn't seem like a viable option for me, so I decided to add basic support for yarn to rn-nodeify. Not sure if this is sufficient, I'm very new to JavaScript and submitting PR's, so comments are welcome (or feel free to disregard if this isn't useful).

To use, simply add `--yarn` when invoking the rn-nodeify command. I tested with yarn 0.21.3 on OSX, and everything seemed to work ok.